### PR TITLE
Fix diagram cell alignment in Lance discrete sparse sketch

### DIFF
--- a/static/sketches/lance-discrete-sparse-layout/index.html
+++ b/static/sketches/lance-discrete-sparse-layout/index.html
@@ -300,16 +300,16 @@
       overflow: hidden;
     }
 
-    .fact {
+    .hero-points .fact {
       padding: var(--space-4);
       border-left: 1px solid var(--border);
     }
 
-    .fact:first-child {
+    .hero-points .fact:first-child {
       border-left: none;
     }
 
-    .fact b {
+    .hero-points .fact b {
       display: block;
       margin-bottom: var(--space-1);
       color: var(--fg);
@@ -318,7 +318,7 @@
       text-transform: uppercase;
     }
 
-    .fact span {
+    .hero-points .fact span {
       display: block;
       color: var(--fg-muted);
       font-size: 13px;
@@ -1181,12 +1181,12 @@
         grid-template-columns: 1fr;
       }
 
-      .fact {
+      .hero-points .fact {
         border-left: none;
         border-top: 1px solid var(--border);
       }
 
-      .fact:first-child {
+      .hero-points .fact:first-child {
         border-top: none;
       }
 


### PR DESCRIPTION
The numbers inside the diagram cells on `sketches/lance-discrete-sparse-layout/` were visibly off center: amber `fact` cells in the hero row-domain strip rendered their digits ~5px too low, the matching cells in the selection diagram were stretched taller than their siblings, and the legend showed a stray divider before "structural fact".

Root cause: the hero point cards (BYTES/SCAN/TAKE) styled themselves with a bare `.fact` selector, which also matched every `class="cell fact"` diagram cell and the legend item, leaking `padding: 16px` and a `border-left` into them. The meta-strip cells escaped only because their own `padding` declaration had higher specificity.

Scoping the card rules under `.hero-points` (including the responsive overrides) removes the leak while leaving the cards themselves unchanged. Verified in-browser: all 59 diagram cells now center their text within 0.1px, and the selection diagram cell heights match again.
